### PR TITLE
Refuse to write a run into the directory the lifecycle deletes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,9 @@ out of order is *incomplete*.
    updates the relevant `docs/design/` doc; every unit places tests before code.
 2. **Branch, isolate, sync.** One explicit task per branch, developed in its own worktree
    (Claude Code's built-in worktree tooling, which puts it at `.claude/worktrees/<branch>` —
-   keep that path gitignored, and remove the worktree once its branch lands). Never develop on
+   keep that path gitignored, and remove the worktree once its branch lands). **Experiment
+   artefacts never land inside a worktree** — they go to the main working tree, because
+   `git worktree remove` takes gitignored data with it without a word. Never develop on
    `main`. Rebase onto latest `main` before developing; land via feature branch + PR, no direct
    pushes to `main`.
 3. **Docs first.** Read, then update, the relevant `docs/design/` doc(s) before any test or

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -59,6 +59,11 @@
 
 - 入 git 的白名单:逐题记录、题目集、报表,以及 `experiments/results/` 下的 write-up。
   其余(store、工作目录、进度日志)不入。
+- **实验产物只落主工作区,绝不落在 worktree 内。** worktree 是代码的隔离区,不是数据的:
+  worktree 路径与 run 产物都被 gitignore,而 `git worktree remove` **不因忽略文件而拒绝**
+  (status 为空,不加 force 即删),再叠上「分支落地即删 worktree」的规矩,语料会随分支蒸发。
+  在 worktree 里跑实验时,写入路径用绝对路径指回主工作区;harness 对落在 worktree 下的
+  写入型路径拒绝启动。
 - **冻结语料不可删**:被任何读侧结果锚定的 store 树。清单与理由见
   [experiments/README.md](../experiments/README.md)。删掉它丢的不是结论,
   是「再跑一条臂来比」的能力。

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -31,7 +31,7 @@
 | `core/manage` | `tests/unit/test_manage.py` |
 | `mcp/server`·`mcp/tools`(三入口一致性) | `tests/system/test_entry_equivalence.py` |
 | 红队(poisoning / 恶意 frontmatter / 越界写) | `tests/redteam/test_poisoning.py` |
-| `harness/*`(回放驱动器、隔离闸、指标、报表) | `tests/system/test_harness.py` |
+| `harness/*`(回放驱动器、隔离闸、写入路径闸、指标、报表) | `tests/system/test_harness.py` |
 
 ## 判分器是仪器,仪器要标定
 

--- a/packages/harness/src/agent_memory/harness/main.py
+++ b/packages/harness/src/agent_memory/harness/main.py
@@ -23,6 +23,7 @@ from . import exam as exam_module
 from . import interop as interop_module
 from . import judge as judge_module
 from . import report as report_module
+from . import workspace as workspace_module
 from .driver import Driver
 from .hosts import DEFAULT_MODEL, DIALECTS, HOST_CLAUDE_CODE, Host, HostSpec
 from .judge import Judge
@@ -61,7 +62,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     if not getattr(args, "handler", None):
         parser.print_help()
         return EXIT_OK
-    return args.handler(args)
+    try:
+        return args.handler(args)
+    except workspace_module.DisposableWorkspace as refusal:
+        print(json.dumps({"error": str(refusal)}), file=sys.stderr)
+        return EXIT_ERROR
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -151,7 +156,7 @@ def _parser() -> argparse.ArgumentParser:
 
 def _prepare(args: argparse.Namespace) -> int:
     count = dataset.trim(
-        pathlib.Path(args.source), pathlib.Path(args.target), args.sessions
+        pathlib.Path(args.source), workspace_module.for_writing(args.target), args.sessions
     )
     print(json.dumps({"episodes": count, "target": args.target, "sessions": args.sessions}))
     return EXIT_OK
@@ -162,7 +167,7 @@ def _run(args: argparse.Namespace) -> int:
         dataset.load(pathlib.Path(args.suite)), args.per_type, args.seed
     )
     selected = arms_module.parse(args.arms)
-    workspace = pathlib.Path(args.workspace)
+    workspace = workspace_module.for_writing(args.workspace)
     sink = MetricsSink(workspace)
     workspace.mkdir(parents=True, exist_ok=True)
     (workspace / QUESTIONS_FILENAME).write_text(
@@ -239,7 +244,7 @@ def _coerce(current: object, raw: str) -> object:
 
 
 def _regrade(args: argparse.Namespace) -> int:
-    workspace = pathlib.Path(args.workspace)
+    workspace = workspace_module.for_writing(args.workspace)
     sink = MetricsSink(workspace)
     records = sink.records()
     judge = Judge(
@@ -340,7 +345,9 @@ def _interop(args: argparse.Namespace) -> int:
     if missing:
         print(json.dumps({"error": "host binaries not found", "hosts": missing}), file=sys.stderr)
         return EXIT_ERROR
-    results = interop_module.matrix(hosts, INTEROP_FACT, pathlib.Path(args.workspace))
+    results = interop_module.matrix(
+        hosts, INTEROP_FACT, workspace_module.for_writing(args.workspace)
+    )
     if args.json:
         print(json.dumps([result.as_dict() for result in results], indent=REPORT_INDENT))
     else:
@@ -385,7 +392,7 @@ def _provider_env(name: str) -> str:
 def _sleep_stores(args: argparse.Namespace) -> int:
     """Copy first: the un-slept arm has to survive as the control."""
     source = pathlib.Path(args.stores)
-    target = pathlib.Path(args.target)
+    target = workspace_module.for_writing(args.target)
     if target.exists():
         raise FileExistsError(f"{target} already exists")
     shutil.copytree(source, target)

--- a/packages/harness/src/agent_memory/harness/workspace.py
+++ b/packages/harness/src/agent_memory/harness/workspace.py
@@ -1,0 +1,34 @@
+"""Where a run may write. A worktree is an isolation for code, never for corpora.
+
+Worktree paths and run artefacts are both gitignored, and `git worktree remove` does not
+refuse over ignored files — status is clean, the removal succeeds, and hours of write pass
+go with it. The lifecycle then says to remove a worktree as soon as its branch lands, so a
+run that wrote there is scheduled for deletion by the rules the project already follows.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+WORKTREE_MARKER = (".claude", "worktrees")
+
+REFUSAL = (
+    "{path} is inside a worktree ({marker}). A worktree and everything gitignored inside it "
+    "is deleted by `git worktree remove` without warning, and the lifecycle removes one as "
+    "soon as its branch lands. Point this at the main working tree instead, by absolute path."
+)
+
+
+class DisposableWorkspace(ValueError):
+    """A write was aimed at a directory the project deletes on purpose."""
+
+
+def for_writing(raw: str | pathlib.Path) -> pathlib.Path:
+    path = pathlib.Path(raw).expanduser().resolve()
+    parts = path.parts
+    for index in range(len(parts) - 1):
+        if parts[index : index + len(WORKTREE_MARKER)] == WORKTREE_MARKER:
+            raise DisposableWorkspace(
+                REFUSAL.format(path=path, marker="/".join(WORKTREE_MARKER))
+            )
+    return path

--- a/tests/system/test_harness.py
+++ b/tests/system/test_harness.py
@@ -384,3 +384,53 @@ def test_metrics_records_round_trip_through_the_sink(tmp_path):
     sink.append(record)
     assert sink.records()[0]["episode_id"] == "q1"
     assert set(sink.records()[0]) == set(record.as_dict())
+
+
+def test_a_write_path_inside_a_worktree_is_refused(tmp_path):
+    from agent_memory.harness.workspace import DisposableWorkspace, for_writing
+
+    inside = tmp_path / ".claude" / "worktrees" / "feat-x" / "experiments" / "runs" / "p1"
+    with pytest.raises(DisposableWorkspace) as refusal:
+        for_writing(inside)
+    assert "worktree" in str(refusal.value)
+
+
+def test_a_write_path_in_the_main_tree_is_accepted_and_absolute(tmp_path):
+    from agent_memory.harness.workspace import for_writing
+
+    resolved = for_writing(tmp_path / "experiments" / "runs" / "p1")
+
+    assert resolved.is_absolute()
+    assert resolved == (tmp_path / "experiments" / "runs" / "p1").resolve()
+
+
+def test_a_directory_merely_named_worktrees_is_not_a_worktree(tmp_path):
+    from agent_memory.harness.workspace import for_writing
+
+    assert for_writing(tmp_path / "worktrees" / "runs")
+
+
+def test_every_writing_subcommand_guards_its_path():
+    import inspect
+
+    from agent_memory.harness import main as main_module
+
+    source = inspect.getsource(main_module)
+    for handler in ("_run", "_regrade", "_interop", "_sleep_stores", "_prepare"):
+        body = source.split(f"def {handler}(")[1].split("\ndef ")[0]
+        assert "for_writing(" in body, f"{handler} writes without guarding its path"
+
+
+def test_the_cli_refuses_a_worktree_target_without_a_traceback(tmp_path, capsys):
+    from agent_memory.harness.main import main
+
+    code = main(
+        [
+            "sleep-stores",
+            "--stores", str(tmp_path / "src"),
+            "--target", str(tmp_path / ".claude" / "worktrees" / "b" / "stores"),
+        ]
+    )
+
+    assert code == 1
+    assert "worktree" in capsys.readouterr().err


### PR DESCRIPTION
A worktree and a run's artefacts are both gitignored, and `git worktree remove` does not treat
ignored files as a reason to stop. Measured on a scratch repo: 5 MB of ignored data under a
worktree, `git status` clean, `git worktree remove` (no `--force`) — deleted, no warning. The
lifecycle then says to remove a worktree as soon as its branch lands, so a run that wrote
inside one is scheduled for deletion by the rules the project already follows. Two removals
have already come close to taking the frozen stores that P5 through P9 are anchored to.

Nothing forbade it. `CLAUDE.md` said where a worktree goes and to remove it once it lands; the
experiments README said which stores may not be deleted; neither said where a run may write.
Together they were a trap rather than a guardrail.

**Rule** — written in `docs/experiments.md` §6 and in the `CLAUDE.md` lifecycle: experiment
artefacts land in the main working tree, never inside a worktree; from inside one, point write
paths back by absolute path.

**Enforcement** — `harness/workspace.py` resolves every path a run writes to and refuses one
under `.claude/worktrees`, naming the reason and the fix. Wired into the five subcommands that
write: `prepare --target`, `run --workspace`, `regrade --workspace`, `interop --workspace`,
`sleep-stores --target`. Read-only paths are untouched. The refusal exits 1 with a JSON error
on stderr rather than a traceback.

Tests: the guard itself (refusal, acceptance, absolute resolution, and that a directory merely
named `worktrees` is not one), a source check that no writing subcommand skips it, and a CLI
test for the clean exit. 197 pass; ruff and mypy clean.

Verified end to end against the CLI, not only in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
