### PR TITLE
fix(frontmatter): handle quote characters inside unquoted inline-array values

### DIFF
--- a/packages/core/src/agent_memory/core/frontmatter.py
+++ b/packages/core/src/agent_memory/core/frontmatter.py
@@ -95,19 +95,30 @@ def _split_items(inner: str) -> list[str]:
     items: list[str] = []
     current: list[str] = []
     quote: str | None = None
+    at_value_start = True
     for char in inner:
         if quote:
             if char == quote:
                 quote = None
             current.append(char)
-        elif char in ("'", '"'):
+            at_value_start = False
+        elif char in ("'", '"') and at_value_start:
             quote = char
             current.append(char)
+            at_value_start = False
         elif char == ",":
             items.append("".join(current))
             current = []
+            at_value_start = True
+        elif char in (" ", "\t"):
+            if not current:
+                at_value_start = True
+            else:
+                current.append(char)
+                at_value_start = False
         else:
             current.append(char)
+            at_value_start = False
     items.append("".join(current))
     return [item for item in (item.strip() for item in items) if item]
 

--- a/tests/unit/test_frontmatter.py
+++ b/tests/unit/test_frontmatter.py
@@ -1,0 +1,75 @@
+"""Frontmatter dialect: parse and render round-trip, including inline arrays."""
+
+from agent_memory.core import frontmatter
+
+
+def _round_trip(fields, body):
+    text = frontmatter.render(fields, body)
+    parsed_fields, parsed_body = frontmatter.parse(text)
+    return parsed_fields, parsed_body
+
+
+def test_parse_returns_empty_dict_when_no_frontmatter():
+    fields, body = frontmatter.parse("just body text\n")
+    assert fields == {}
+    assert body == "just body text\n"
+
+
+def test_parse_round_trip_preserves_scalar_fields():
+    fields = {"name": "test-entry", "status": "active", "weight": 1.5}
+    parsed, _ = _round_trip(fields, "body content")
+    assert parsed["name"] == "test-entry"
+    assert parsed["status"] == "active"
+    assert parsed["weight"] == 1.5
+
+
+def test_inline_array_of_quoted_strings_round_trips():
+    fields = {"links": ["slug-one", "slug-two"]}
+    parsed, _ = _round_trip(fields, "body")
+    assert parsed["links"] == ["slug-one", "slug-two"]
+
+
+def test_inline_array_with_unquoted_value_containing_apostrophe():
+    """An unquoted value with a quote character mid-value must not enter quote mode.
+
+    Before the fix, the apostrophe in 'it's' toggled quote tracking on,
+    which prevented the comma from splitting the next item correctly.
+    """
+    text = "---\nlinks: [it's, done]\n---\nbody\n"
+    fields, body = frontmatter.parse(text)
+    assert fields["links"] == ["it's", "done"]
+
+
+def test_inline_array_with_quoted_value_containing_other_quote_type():
+    """A double-quoted value containing a single quote must round-trip."""
+    text = '---\nlinks: ["it\'s done", "hello"]\n---\nbody\n'
+    fields, body = frontmatter.parse(text)
+    assert fields["links"] == ["it's done", "hello"]
+
+
+def test_inline_array_single_unquoted_value_with_apostrophe():
+    text = "---\ntags: [it's]\n---\nbody\n"
+    fields, body = frontmatter.parse(text)
+    assert fields["tags"] == ["it's"]
+
+
+def test_empty_inline_array():
+    fields = {"links": []}
+    parsed, _ = _round_trip(fields, "body")
+    assert parsed["links"] == []
+
+
+def test_render_wraps_strings_needing_quoting():
+    rendered = frontmatter._render_scalar("hello: world")
+    assert rendered == '"hello: world"'
+
+
+def test_render_scalar_boolean_and_null():
+    assert frontmatter._render_scalar(True) == "true"
+    assert frontmatter._render_scalar(False) == "false"
+    assert frontmatter._render_scalar(None) == "null"
+
+
+def test_split_document_with_no_closing_delimiter_returns_none_header():
+    header, body = frontmatter.split_document("---\nname: test\nno closing marker\n")
+    assert header is None


### PR DESCRIPTION
## Problem

The frontmatter dialect parses inline arrays (`links: [a, b, c]`) with a
single-pass state machine in `_split_items`. The quote-tracking loop
treats **any** quote character (`'` or `"`) as a toggle into/out of
quoted mode, even when the quote appears mid-value rather than at the
value boundary.

An unquoted value containing a quote character — `it's` for example —
enters quote mode on the apostrophe and never exits. Every subsequent
comma is then swallowed as part of the quoted string, so the array
collapses into a single broken item.

```
>>> frontmatter.parse("---\nlinks: [it's, done]\n---\nbody\n")
{'links': ['"it\'s, done"']}    # wrong: 1 item, includes the comma
```

The render path always wraps list items in quotes, so the round-trip
via `render → parse` happens to work. The bug surfaces when a front-
matter file is edited by hand (which the project encourages — the
files are the source of truth) and an unquoted value contains an
apostrophe or a double-quote character.

## Fix

Track whether the cursor is at the start of a new value (right after
the opening bracket, a comma, or leading whitespace). Only enter quote
mode when a quote character appears at that position. A quote in the
middle of an unquoted value is now treated as a regular character.

```
>>> frontmatter.parse("---\nlinks: [it's, done]\n---\nbody\n")
{'links': ["it's", "done"]}     # correct: 2 items
```

## Testing

Added `tests/unit/test_frontmatter.py` covering the parse / render
round-trip, the unquoted-apostrophe case, a quoted value that contains
the other quote type, and the existing scalar and empty-array paths.

```
$ python3 -m pytest tests/unit/test_frontmatter.py -v
10 passed in 0.17s
```
