### PR TITLE
fix(locking): use context manager to guarantee lock file handle cleanup

### DIFF
--- a/packages/core/src/agent_memory/core/locking.py
+++ b/packages/core/src/agent_memory/core/locking.py
@@ -17,8 +17,7 @@ def store_lock(layout: StoreLayout) -> Iterator[None]:
     timeout = layout.config.storage.lock_timeout_seconds
     poll = layout.config.storage.lock_poll_seconds
     deadline = time.monotonic() + timeout
-    handle = layout.lock_file.open("a+")
-    try:
+    with layout.lock_file.open("a+", encoding="utf-8") as handle:
         while True:
             try:
                 fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -31,5 +30,3 @@ def store_lock(layout: StoreLayout) -> Iterator[None]:
             yield
         finally:
             fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
-    finally:
-        handle.close()

--- a/tests/unit/test_locking.py
+++ b/tests/unit/test_locking.py
@@ -1,0 +1,62 @@
+"""The advisory lock must always release its file handle, even on error."""
+
+import pathlib
+
+import pytest
+
+from agent_memory.core.clock import FrozenClock
+from agent_memory.core.config import Config
+from agent_memory.core.locking import store_lock
+from agent_memory.core.paths import StoreLayout
+
+
+def _layout(tmp_path: pathlib.Path) -> StoreLayout:
+    config = Config.default()
+    layout = StoreLayout(root=tmp_path / "store", config=config)
+    layout.ensure()
+    return layout
+
+
+def test_store_lock_acquires_and_releases(tmp_path):
+    layout = _layout(tmp_path)
+    entered = False
+    with store_lock(layout):
+        entered = True
+    assert entered
+    # Lock file exists after first use
+    assert layout.lock_file.exists()
+
+
+def test_store_lock_creates_state_dir_if_missing(tmp_path):
+    config = Config.default()
+    layout = StoreLayout(root=tmp_path / "new-store", config=config)
+    # state_dir does not exist yet
+    assert not layout.state_dir.exists()
+    with store_lock(layout):
+        pass
+    assert layout.state_dir.exists()
+    assert layout.lock_file.exists()
+
+
+def test_store_lock_handle_is_closed_after_use(tmp_path):
+    """After the context manager exits, the file handle must be closed.
+
+    The old code opened the handle before a try/finally, so an unexpected
+    error between open() and the try block would leak it. Using a `with`
+    statement guarantees the handle is closed on every exit path.
+    """
+    layout = _layout(tmp_path)
+    with store_lock(layout):
+        pass
+    # Try to acquire the lock again — this would deadlock if the handle
+    # were still held by the first acquisition (on the same fd).
+    with store_lock(layout):
+        pass
+
+
+def test_lock_file_is_opened_with_explicit_encoding(tmp_path):
+    """The lock file open() call must specify encoding to avoid relying
+    on the locale default, even though the handle is used only for flock()."""
+    import inspect
+    source = inspect.getsource(store_lock)
+    assert "encoding=" in source, "lock file open() should specify encoding"


### PR DESCRIPTION
The store lock in `locking.py` opened the lock file handle *before* the
`try:` block that guarantees cleanup:

```python
handle = layout.lock_file.open("a+")   # opened here
try:                                    # cleanup starts here
    while True:
        ...
```

Two things were off:

- No `encoding=` on the `open()` call. The handle is only used as a
  file descriptor for `fcntl.flock()`, so the text encoding never
  matters at runtime — but relying on the locale default for a binary-
  style operation is a code-smell that linters flag and that could
  surface as a surprise on an unusual platform.

- If anything unexpected happened between the `open()` and the `try:`
  (or in a future refactor that moves code around), the handle would
  leak. At the operator's write rates the leak would be invisible, but
  it's still a file descriptor that should always be closed.

Switched to a `with` statement so the handle is closed on every exit
path — success, `LockTimeoutError`, or anything else the runtime might
throw:

```python
with layout.lock_file.open("a+", encoding="utf-8") as handle:
    while True:
        try:
            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
            break
        except BlockingIOError:
            ...
    try:
        yield
    finally:
        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
```

Added `tests/unit/test_locking.py` with four tests covering the
acquire/release cycle, state-dir auto-creation, handle re-acquisition,
and a source-inspection check that `encoding=` is specified.

```
$ python3 -m pytest tests/unit/test_locking.py -v
4 passed in 0.15s
```
