### PR TITLE
fix(portability): refuse path traversal in import_into

### DIFF
--- a/packages/core/src/agent_memory/core/portability.py
+++ b/packages/core/src/agent_memory/core/portability.py
@@ -45,7 +45,9 @@ def import_into(store: Store, payload: dict[str, object]) -> int:
     files = payload.get(KEY_FILES)
     written = 0
     for entry in files if isinstance(files, list) else []:
-        target = store.root / str(entry[KEY_PATH])
+        target = (store.root / str(entry[KEY_PATH])).resolve()
+        if not target.is_relative_to(store.root.resolve()):
+            raise ValueError(f"path traversal refused: {entry[KEY_PATH]}")
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(str(entry[KEY_TEXT]), encoding="utf-8")
         written += 1

--- a/tests/unit/test_portability.py
+++ b/tests/unit/test_portability.py
@@ -1,0 +1,86 @@
+"""Export/import round-trip, and the path-traversal guard on import."""
+
+import pathlib
+
+import pytest
+
+from agent_memory.core import portability
+from agent_memory.core.clock import FrozenClock
+from agent_memory.core.config import Config
+from agent_memory.core.store import Store
+
+
+@pytest.fixture
+def source_store(tmp_path):
+    config = Config.default()
+    clock = FrozenClock(__import__("datetime").datetime(2026, 1, 15, 9, 0, tzinfo=__import__("datetime").UTC))
+    store = Store(tmp_path / "src-store", config=config, clock=clock, agent="test")
+    store.init()
+    store.record(
+        abstract="A memory about queues",
+        type="fact",
+        domain="project",
+        name="queue-fact",
+    )
+    return store
+
+
+@pytest.fixture
+def target_store(tmp_path):
+    config = Config.default()
+    clock = FrozenClock(__import__("datetime").datetime(2026, 1, 15, 9, 0, tzinfo=__import__("datetime").UTC))
+    store = Store(tmp_path / "dst-store", config=config, clock=clock, agent="test")
+    store.init()
+    return store
+
+
+def test_export_round_trip_preserves_content(source_store, target_store):
+    payload = portability.export_store(source_store, include_archive=False)
+    written = portability.import_into(target_store, payload)
+    assert written >= 1
+    names = [record.name for record in target_store.records()]
+    assert "queue-fact" in names
+
+
+def test_write_export_creates_file(source_store, tmp_path):
+    out = tmp_path / "export.json"
+    portability.write_export(source_store, out, include_archive=False)
+    assert out.exists()
+    assert out.stat().st_size > 0
+
+
+def test_import_refuses_path_traversal(target_store):
+    """An export payload with a relative path that escapes the store root
+    must be rejected rather than writing outside the store."""
+    payload = {
+        "format": portability.FORMAT_VERSION,
+        "files": [
+            {"path": "../../etc/malicious", "text": "should not land here"},
+        ],
+    }
+    with pytest.raises(ValueError, match="path traversal"):
+        portability.import_into(target_store, payload)
+
+
+def test_import_refuses_absolute_path_outside_store(target_store):
+    """An absolute path in the export payload must not write outside the store."""
+    payload = {
+        "format": portability.FORMAT_VERSION,
+        "files": [
+            {"path": "/tmp/escape", "text": "should not land here"},
+        ],
+    }
+    with pytest.raises(ValueError, match="path traversal"):
+        portability.import_into(target_store, payload)
+
+
+def test_import_allows_valid_relative_paths(target_store):
+    """Normal relative paths within the store must work as before."""
+    payload = {
+        "format": portability.FORMAT_VERSION,
+        "files": [
+            {"path": "project/valid-record.md", "text": "---\nname: valid\n---\nbody"},
+        ],
+    }
+    written = portability.import_into(target_store, payload)
+    assert written == 1


### PR DESCRIPTION
- `import_into` builds the target path as `store.root / entry["path"]`
  and writes to it without checking that the resolved path stays under
  the store root.
- An export payload carrying `../../etc/malicious` or an absolute path
  like `/tmp/escape` would write outside the store directory. The
  export path cannot produce such entries (`relative_to` constrains
  them), but `import_into` is a public function that any caller can
  reach with an arbitrary payload.

**Fix:** resolve the target path and verify it is relative to the
resolved store root before writing. Refuse with a `ValueError` if the
path escapes.

```python
target = (store.root / str(entry[KEY_PATH])).resolve()
if not target.is_relative_to(store.root.resolve()):
    raise ValueError(f"path traversal refused: {entry[KEY_PATH]}")
```

**Files changed:**
- `packages/core/src/agent_memory/core/portability.py` — 2-line guard
  in `import_into`
- `tests/unit/test_portability.py` — 5 tests: round-trip, file export,
  `../` traversal refusal, absolute path refusal, valid relative path

```
$ python3 -m pytest tests/unit/test_portability.py -v
5 passed in 0.97s
```
