### PR TITLE
Reposition the README around the retrieval design

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,18 @@
 An agent that closes its session forgets everything it learned in it. agent-memory is the
 runtime that fixes that, for any agent — not only coding ones.
 
-Three retrieval traditions each get one part of the problem right, and each pays for it
-somewhere else. Knowledge graphs hold relations but need a build step and a query language.
-Vector search ranks well but hands back opaque chunks. A plain file tree is the most
-AI-readable thing there is and browses beautifully, but on its own it does not rank. This
-runtime keeps all three and drops the costs: relations live as links inside the memories
-themselves, a local index ranks them, and the store stays an ordinary directory an agent can
-`ls` and `grep`. Recall gets more precise without becoming a black box, and it stays fast
-because nothing in the read path calls a model or crosses a network.
+Agent memory has grown along two architectural lines. One builds a **retrieval engine** —
+embeddings, a knowledge graph, a ranking pipeline — which finds the right thing, but hands the
+agent an opaque chunk it cannot inspect and a store it cannot migrate off. The other hands the
+agent a **filesystem** — markdown it reads directly, browsable with `ls` and `grep`, disclosed
+a level at a time — which is legible and costs nothing to run, but does not rank, and stops
+scaling the moment the tree outgrows a listing.
+
+agent-memory is the two of them in one store: the retrieval engine indexes a filesystem the
+agent can also just read. Relations live as links inside the memories, a local index ranks
+them, and every hit resolves to a whole markdown file on disk. Recall gains the precision of a
+graph and a vector search without giving up a plain directory an agent can walk — and it stays
+fast, because nothing in the read path calls a model or crosses a network.
 
 The other half of the problem is that agents rarely write memory down. Here they do not have
 to remember to: writes fire at conversation boundaries rather than at the agent's discretion,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### agent-memory: the long-term memory runtime for AI agents
 
-<a href="docs/design/index.md">Design</a> · <a href="CLAUDE.md">Invariants</a> · <a href="experiments/results/index.md">Experiments</a> · <a href="docs/testing.md">Testing</a> · <a href="https://github.com/tigerless-labs/agent-memory/issues">Issues</a>
+<a href="CLAUDE.md">Invariants</a> · <a href="skills/agent-memory/SKILL.md">Skill</a> · <a href="https://github.com/tigerless-labs/agent-memory/issues">Issues</a>
 
 ![](https://img.shields.io/badge/version-0.1.0-369eff?labelColor=black&style=flat-square)
 ![](https://img.shields.io/badge/python-3.12+-ffcb47?labelColor=black&style=flat-square)
@@ -15,35 +15,51 @@
 
 ## What is agent-memory
 
-agent-memory is a local-first, agent-agnostic long-term memory runtime. Memories are plain
-markdown files in one store — the single source of truth — and the SQLite index beside them is
-a cache you can delete at any time. Writes are triggered at conversation boundaries, not at the
-agent's discretion; an independent sleep-time Manage pass then consolidates, ages, and forgets
-by value, while nothing it touches is destroyed. Claude Code, Codex CLI, and any agent that can
-run a shell command share the same store.
+An agent that closes its session forgets everything it learned in it. agent-memory is the
+runtime that fixes that, for any agent — not only coding ones.
+
+Three retrieval traditions each get one part of the problem right, and each pays for it
+somewhere else. Knowledge graphs hold relations but need a build step and a query language.
+Vector search ranks well but hands back opaque chunks. A plain file tree is the most
+AI-readable thing there is and browses beautifully, but on its own it does not rank. This
+runtime keeps all three and drops the costs: relations live as links inside the memories
+themselves, a local index ranks them, and the store stays an ordinary directory an agent can
+`ls` and `grep`. Recall gets more precise without becoming a black box, and it stays fast
+because nothing in the read path calls a model or crosses a network.
+
+The other half of the problem is that agents rarely write memory down. Here they do not have
+to remember to: writes fire at conversation boundaries rather than at the agent's discretion,
+they run beside the task instead of blocking it, and whatever distillation misses stays
+recoverable from append-only raw material. An independent sleep-time pass then consolidates,
+ages, and forgets by value.
+
+Markdown files in one store are the single source of truth. The SQLite index beside them is a
+cache you can delete at any time. Claude Code, Codex CLI, and anything else that can run a
+shell command share the same store.
 
 ## Why agent-memory
 
+- **Three read tracks, so a miss on one is not a miss.** Deterministic `MEMORY.md` injection at
+  session start; BM25 recall over an FTS5 index, with a vector plugin fused in by RRF when you
+  want one; and the plain directory tree, reachable with `ls` and `grep` when both fail.
+  Same-directory memories are a free neighbourhood, and `links` in the frontmatter carry the
+  graph without a graph database under them.
+- **Progressive disclosure, so precision is not paid for in context.** Index line → abstract →
+  full file → raw material, each level an order of magnitude more expensive than the last and
+  each one a place to stop. Long files add two free rungs: the anchor that matched, and an
+  outline computed at read time.
+- **Write coverage is the system's job, not the agent's judgement.** Distillation is triggered
+  at boundaries and runs without holding up the task; the full trace is copied first, so
+  "missed by the distiller" never means "lost by the system".
 - **Files are the truth; every index is a rebuildable cache.** `rm -rf .index/ && mem rebuild`
   loses zero knowledge — enforced by a test, not promised in a doc. Your memory stays greppable,
-  git-able, and portable off this system. → [Storage](docs/design/domains/storage.md) ·
-  [ADR-001](docs/design/decisions/adr-001-file-truth.md)
-- **A real Manage layer, on its own clock.** Sleep-time consolidation with authority tiers:
-  an unattended pass may add and update, deletion only ever arrives as a proposal you confirm.
-  Every competitor either has no M, or buries it in the write path. →
-  [Manage](docs/design/domains/manage.md)
-- **Updating never destroys.** Supersede leaves the chain intact, `recall --as-of` answers as of
-  a date, and `archive/` keeps the raw material append-only — so "missed by the distiller" never
-  means "lost by the system". → [Storage](docs/design/domains/storage.md)
-- **No LLM client inside the library.** Zero keys to install and no billing surface: judgement is
-  borrowed from the host agent's own CLI, which keeps every write visible in your transcript. →
-  [ADR-002](docs/design/decisions/adr-002-no-llm-in-core.md)
-- **Three read tracks, so a miss on one is not a miss.** Deterministic `MEMORY.md` injection at
-  session start, BM25 recall with progressive disclosure, and the plain directory tree reachable
-  with `ls` and `grep`. → [Recall](docs/design/domains/recall.md)
-- **One write path, one answer per door.** Agent writes and Manage rewrites both go through
-  validate → hash-diff → reindex, and CLI, MCP, and hooks carry zero algorithm between them. →
-  [Architecture](docs/design/architecture/overview.md)
+  git-able, and portable off this system.
+- **A real Manage layer, on its own clock.** Sleep-time consolidation with authority tiers: an
+  unattended pass may add and update, deletion only ever arrives as a proposal you confirm.
+  Every competitor either has no M, or buries it in the write path. Supersede leaves the chain
+  intact and `recall --as-of` answers as of a date, so updating never destroys.
+- **No LLM client inside the library.** Zero keys to install and no billing surface: judgement
+  is borrowed from the host agent's own CLI, which keeps every write visible in your transcript.
 
 The store is the whole data model:
 
@@ -68,15 +84,12 @@ abstract, status, timestamps, links, weight, and provenance; the body is free ma
 ## Proof it works
 
 Measured on LongMemEval-S with a bounded haystack, 120 episodes, `claude -p` (Haiku 4.5) as
-host, one calibrated Sonnet 5 judge, two exam replays per arm. Protocol, every known difference
-between the arms, and the noise floor that decides what counts as a result are in
-[docs/experiments.md](docs/experiments.md); the full ledger is
-[experiments/results/](experiments/results/index.md).
+host, one calibrated Sonnet 5 judge, two exam replays per arm.
 
 | arm | pooled accuracy | paired vs agent-memory |
 |---|---|---|
 | agent-memory W2 | **127/240 = 52.9%** | — |
-| [MemCore](experiments/results/p10-memcore.md) W2 | 86/240 = 35.8% | +37/−17, p=0.009 · +35/−14, p=0.004 |
+| MemCore W2 | 86/240 = 35.8% | +37/−17, p=0.009 · +35/−14, p=0.004 |
 | no memory | 7/120 = 5.8% | +61/−4 · +60/−4, p<0.001 |
 
 Absolute numbers are not comparable to published LongMemEval scores — the haystack is bounded
@@ -84,10 +97,13 @@ to 12 sessions per episode, which makes this a write-strategy study rather than 
 one. The system-to-system row differs in write and read together, so it is an end-to-end
 comparison and licenses no attribution to either half.
 
-**One store, three hosts** ([P1](experiments/results/p1-generality.md)): all 9 ordered
-writer/reader pairs across Claude Code, Codex CLI, and Hermes pass — what one host's shell
-writes, another's finds, specifics intact. Pooled net contribution over no memory:
-2/36 → 13/36, p=0.0074.
+**One store, three hosts:** all 9 ordered writer/reader pairs across Claude Code, Codex CLI,
+and Hermes pass — what one host's shell writes, another's finds, specifics intact. Pooled net
+contribution over no memory: 2/36 → 13/36, p=0.0074.
+
+The protocol that decides whether a measurement counts as a result, the full ledger, and the
+raw run records live in `docs/experiments.md` and `experiments/` in the working tree. They ship
+with the source, not with git history.
 
 ## Quick start
 
@@ -120,8 +136,7 @@ rest of the settings alone — SessionStart injects, Stop and SessionEnd distil,
 evicts. Agents that speak MCP get the same core calls through `mem-mcp` (`memory_recall`,
 `memory_read`, `memory_record`, `memory_correct`, `memory_feedback`, `memory_proposals`,
 `memory_decide`). Anything that can run a shell command needs neither: the CLI is the universal
-fallback. → [CLI](docs/design/api/cli.md) · [MCP](docs/design/api/mcp.md) ·
-[Hooks](docs/design/api/hooks.md)
+fallback.
 
 ## Let it sleep
 
@@ -132,7 +147,7 @@ uv run mem decide <id> --accept
 ```
 
 Manage borrows its reasoning from the host CLI you point it at, writes a dream report for the
-pass, and cannot delete anything unattended. → [Manage](docs/design/domains/manage.md)
+pass, and cannot delete anything unattended.
 
 ## Develop
 
@@ -140,5 +155,4 @@ pass, and cannot delete anything unattended. → [Manage](docs/design/domains/ma
 uv run pytest -q && uv run ruff check . && uv run mypy
 ```
 
-The task lifecycle, the invariants a change must not break, and the docs to read before
-touching an area are in [CLAUDE.md](CLAUDE.md).
+The task lifecycle and the invariants a change must not break are in [CLAUDE.md](CLAUDE.md).


### PR DESCRIPTION
## What

Rewrites the README's positioning and removes its dead links.

**Positioning.** The front page now opens on the problem (agents forget between
sessions, for any agent — not only coding ones) and on the design that answers it:
the three retrieval traditions each get one part right, and the store keeps all
three — relations as `links` inside the memories, a local FTS5/BM25 index for
ranking, an ordinary directory for browsing and progressive disclosure. Precision
without a black box; speed because the read path calls no model and crosses no
network. Write coverage is stated as the system's job — boundary-triggered,
non-blocking, trace copied first — rather than the agent's judgement.

**Dead links.** `docs/` and `experiments/` moved to `.gitignore` in `c5a7fc59` and
`6e1b2fe9`, so every `docs/design/...` and `experiments/results/...` link in the
README resolved to a 404 on GitHub. Links removed, text kept; the evidence section
now says explicitly that the ledger ships with the source, not with git history.

Numbers, protocol caveats, and the store layout are unchanged.

## Note

`CLAUDE.md` still links into `docs/` and has the same 404 problem. Left alone here
— it is an agent working file where the paths resolve locally; tracked in TODO.