### PR TITLE
Add the MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Tigerless Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -189,3 +189,7 @@ uv run pytest -q && uv run ruff check . && uv run mypy
 ```
 
 The task lifecycle and the invariants a change must not break are in [CLAUDE.md](CLAUDE.md).
+
+## License
+
+[MIT](LICENSE).

--- a/packages/adapters/pyproject.toml
+++ b/packages/adapters/pyproject.toml
@@ -3,6 +3,7 @@ name = "agent-memory-adapters"
 version = "0.1.0"
 description = "agent-memory host adapters: hooks, setup, injection"
 requires-python = ">=3.12"
+license = "MIT"
 dependencies = ["agent-memory-core"]
 
 [project.scripts]

--- a/packages/cli/pyproject.toml
+++ b/packages/cli/pyproject.toml
@@ -3,6 +3,7 @@ name = "agent-memory-cli"
 version = "0.1.0"
 description = "agent-memory CLI adapter"
 requires-python = ">=3.12"
+license = "MIT"
 dependencies = ["agent-memory-core", "agent-memory-executor"]
 
 [project.scripts]

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -3,6 +3,7 @@ name = "agent-memory-core"
 version = "0.1.0"
 description = "agent-memory core: truth store, index projection, recall, manage"
 requires-python = ">=3.12"
+license = "MIT"
 dependencies = []
 
 [build-system]

--- a/packages/executor/pyproject.toml
+++ b/packages/executor/pyproject.toml
@@ -3,6 +3,7 @@ name = "agent-memory-executor"
 version = "0.1.0"
 description = "agent-memory executors: how the library borrows intelligence from outside itself"
 requires-python = ">=3.12"
+license = "MIT"
 dependencies = ["agent-memory-core"]
 
 [build-system]

--- a/packages/harness/pyproject.toml
+++ b/packages/harness/pyproject.toml
@@ -3,6 +3,7 @@ name = "agent-memory-harness"
 version = "0.1.0"
 description = "agent-memory experiment harness: replay driver, metrics, report"
 requires-python = ">=3.12"
+license = "MIT"
 dependencies = ["agent-memory-core", "agent-memory-cli", "agent-memory-executor"]
 
 [project.scripts]

--- a/packages/mcp/pyproject.toml
+++ b/packages/mcp/pyproject.toml
@@ -3,6 +3,7 @@ name = "agent-memory-mcp"
 version = "0.1.0"
 description = "agent-memory MCP adapter"
 requires-python = ">=3.12"
+license = "MIT"
 dependencies = ["agent-memory-core"]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,8 @@ name = "agent-memory-workspace"
 version = "0.1.0"
 description = "Agent-agnostic, local-first long-term memory runtime"
 requires-python = ">=3.12"
+license = "MIT"
+license-files = ["LICENSE"]
 dependencies = [
     "agent-memory-core",
     "agent-memory-cli",


### PR DESCRIPTION
The repository is public with no license file, which leaves it **all rights reserved** by
default — readable, but not legally usable, modifiable, or redistributable by anyone who finds
it. That is the wrong state to announce a release from.

- `LICENSE` — MIT, copyright 2026 Tigerless Labs.
- `license = "MIT"` in the workspace root and in all six package manifests, plus
  `license-files = ["LICENSE"]` at the root, so a built wheel carries the text rather than just
  the classifier.
- A `## License` line at the foot of the README.

Copyright holder is the GitHub org that owns the repo; say the word if it should be a person or
a different entity instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)