### PR TITLE
Make the store lock and the hook timeout work on Windows

### DIFF
--- a/packages/adapters/src/agent_memory/adapters/hook_entry.py
+++ b/packages/adapters/src/agent_memory/adapters/hook_entry.py
@@ -139,11 +139,17 @@ def _arm(seconds: float) -> None:
     def _raise(signum: int, frame: FrameType | None) -> None:
         raise _Timeout()
 
+    # SIGALRM and setitimer are POSIX-only. On Windows the hook simply runs
+    # without a wall-clock guard rather than failing to start.
+    if not hasattr(signal, "SIGALRM"):
+        return
     signal.signal(signal.SIGALRM, _raise)
     signal.setitimer(signal.ITIMER_REAL, seconds)
 
 
 def _disarm() -> None:
+    if not hasattr(signal, "setitimer"):
+        return
     signal.setitimer(signal.ITIMER_REAL, 0)
 
 

--- a/packages/core/src/agent_memory/core/locking.py
+++ b/packages/core/src/agent_memory/core/locking.py
@@ -3,12 +3,33 @@
 from __future__ import annotations
 
 import contextlib
-import fcntl
+import os
 import time
 from collections.abc import Iterator
+from typing import IO
 
 from .errors import LockTimeoutError
 from .paths import StoreLayout
+
+if os.name == "nt":
+    import msvcrt
+
+    def _acquire(handle: IO[str]) -> None:
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+
+    def _release(handle: IO[str]) -> None:
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+
+else:
+    import fcntl
+
+    def _acquire(handle: IO[str]) -> None:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    def _release(handle: IO[str]) -> None:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
 @contextlib.contextmanager
@@ -21,15 +42,15 @@ def store_lock(layout: StoreLayout) -> Iterator[None]:
     try:
         while True:
             try:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                _acquire(handle)
                 break
-            except BlockingIOError:
+            except OSError:
                 if time.monotonic() >= deadline:
                     raise LockTimeoutError(f"store lock busy for {timeout}s") from None
                 time.sleep(poll)
         try:
             yield
         finally:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            _release(handle)
     finally:
         handle.close()


### PR DESCRIPTION
`agent-memory` does not start on Windows. `core/locking.py` imports `fcntl` at module level, so every entry point — `mem`, `mem-hook`, `mem-mcp` — dies with `ModuleNotFoundError: No module named 'fcntl'` before it can do anything.

This PR makes the two POSIX-only spots portable. Both are narrow.

### `core/locking.py`

`store_lock` used `fcntl.flock` for the pipeline-level advisory lock. It now switches on `os.name`:

- **Windows**: `msvcrt.locking`, taking one byte at position 0 with `LK_NBLCK` and releasing it with `LK_UNLCK`.
- **Everything else**: the same `fcntl.flock` calls as before.

The contention branch now catches `OSError` rather than `BlockingIOError`. That is deliberate: `msvcrt.locking` raises a plain `OSError` when the region is held, and `BlockingIOError` is a subclass of `OSError`, so the POSIX path keeps behaving exactly as it did.

### `adapters/hook_entry.py`

`_arm` and `_disarm` used `signal.SIGALRM` and `signal.setitimer`, neither of which exists on Windows. Both are now guarded with `hasattr`, so on Windows the hook runs without a wall-clock guard instead of failing to start.

That felt like the right trade-off given the module's own docstring: a hook that breaks its host is worse than a hook that never fires. Happy to swap it for a thread-based timeout if you would rather keep the guard on every platform.

### No behaviour change on POSIX

The same `fcntl` calls run on the same paths. The Windows branch is only reachable when `os.name == "nt"`.

### Verification

Windows 11 ARM64, CPython 3.12.

- `mem init`, `mem record`, `mem recall` complete a full round trip, and BM25 recall returns the seeded entries with sensible ranking.
- `mem-mcp` answers an `initialize` plus `tools/list` handshake over stdio with its five tools.
- Test suite: **377 passed**.

The 11 remaining failures are unrelated to this change and were present in the same form before it:

- 9 are the `memcore` harness attempting to exec a Linux binary (`OSError: [WinError 193]`).
- 2 are assertions expecting POSIX separators (`fact/rogue.md`) where the library returns `os.sep` paths (`fact\rogue.md`).

That second group points at a separate portability wrinkle: relative paths in `IndexReport` are built with the platform separator rather than normalised to `/`. It is arguably inconsistent with the portable-store promise, but it is a distinct concern and I left it out of this PR rather than widening the diff. Glad to open a follow-up if you would like it fixed.
