### PR TITLE
Persist explicit memory feedback

### DIFF
--- a/packages/core/src/agent_memory/core/store.py
+++ b/packages/core/src/agent_memory/core/store.py
@@ -366,7 +366,7 @@ class Store:
         current.weight = min(
             self.config.weight.ceiling, max(self.config.weight.floor, current.weight + delta)
         )
-        return current
+        return self.write(current)
 
     def read(self, name: str, level: str = LEVEL_FULL) -> ReadResult:
         if level not in LEVELS:

--- a/tests/unit/test_recall.py
+++ b/tests/unit/test_recall.py
@@ -5,7 +5,7 @@ import hashlib
 from agent_memory.core.access_log import AccessLog
 from agent_memory.core.database import Database
 from agent_memory.core.recall import Recall
-from agent_memory.core.store import LEVEL_ABSTRACT, LEVEL_OUTLINE
+from agent_memory.core.store import LEVEL_ABSTRACT, LEVEL_OUTLINE, Store
 
 
 def _names(hits):
@@ -87,9 +87,13 @@ def test_weight_reorders_two_otherwise_comparable_hits(seeded):
         name="drain-notes-a",
     )
     baseline = _names(Recall(seeded).recall("deploy notes drain window"))
+    before = seeded.find("drain-notes-b").weight
     seeded.feedback("drain-notes-b", seeded.config.weight.boost_step)
-    boosted = _names(Recall(seeded).recall("deploy notes drain window"))
-    assert boosted.index("drain-notes-b") <= baseline.index("drain-notes-b")
+    reopened = Store(seeded.root, config=seeded.config, clock=seeded.clock)
+    boosted = _names(Recall(reopened).recall("deploy notes drain window"))
+    assert baseline.index("drain-notes-a") < baseline.index("drain-notes-b")
+    assert boosted.index("drain-notes-b") < boosted.index("drain-notes-a")
+    assert reopened.find("drain-notes-b").weight == before + seeded.config.weight.boost_step
 
 
 def test_recall_writes_the_access_log_and_leaves_truth_bytes_untouched(seeded):


### PR DESCRIPTION
## Summary

- persist explicit weight feedback through the store write path
- rebuild the search projection so later recall uses the updated weight
- verify persistence by reopening the store in the regression test

## Problem

Store.feedback() returned an updated in-memory record, but neither the Markdown source of truth nor the SQLite search projection was updated. Reopening the store restored the old weight and recall ranking.

## Testing

- uv run pytest -q --cov=agent_memory --cov-report=term-missing --cov-fail-under=85 (388 passed, 90.91% coverage)
- uv run ruff check .
- uv run mypy