### PR TITLE
Match recall scopes by complete path components

### DIFF
--- a/packages/core/src/agent_memory/core/recall.py
+++ b/packages/core/src/agent_memory/core/recall.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import dataclasses
 import datetime as dt
+import pathlib
 import sqlite3
 
 from . import timestamp
@@ -113,7 +114,9 @@ class Recall:
         return eligible
 
     def _in_scope(self, path: str, scope: str) -> bool:
-        return path.startswith(scope.strip("/"))
+        path_parts = pathlib.PurePath(path).parts
+        scope_parts = pathlib.PurePath(scope.strip("/\\")).parts
+        return bool(scope_parts) and path_parts[: len(scope_parts)] == scope_parts
 
     def _current_at(self, row: sqlite3.Row, moment: dt.datetime) -> bool:
         if timestamp.parse(str(row["valid_from"])) > moment:

--- a/tests/unit/test_recall.py
+++ b/tests/unit/test_recall.py
@@ -5,6 +5,7 @@ import hashlib
 from agent_memory.core.access_log import AccessLog
 from agent_memory.core.database import Database
 from agent_memory.core.recall import Recall
+from agent_memory.core.schema import MemorySchema, render
 from agent_memory.core.store import LEVEL_ABSTRACT, LEVEL_OUTLINE
 
 
@@ -65,6 +66,29 @@ def test_scope_restricts_by_path_prefix(seeded):
     hits = Recall(seeded).recall("deploy queue drain answers", scope="experience")
     assert hits
     assert {hit.type for hit in hits} == {"experience"}
+
+
+def test_scope_matches_a_complete_path_component(store):
+    extra = MemorySchema(
+        type="experience-archive",
+        description="Archived experiences used to test a colliding scope prefix.",
+        key=("subject",),
+    )
+    store.schemas.path_for(extra.type).write_text(render(extra), encoding="utf-8")
+    store.record(
+        abstract="Shared scope marker in the active experience domain",
+        type="experience",
+        name="active-scope-marker",
+    )
+    store.record(
+        abstract="Shared scope marker in the archive domain",
+        type=extra.type,
+        fields={"subject": "archive-scope-marker"},
+    )
+
+    hits = Recall(store).recall("shared scope marker", scope="experience")
+
+    assert _names(hits) == ["active-scope-marker"]
 
 
 def test_l0_entries_carry_the_full_contract(seeded):


### PR DESCRIPTION
## Summary

- compare recall scopes against complete path components
- prevent a scope such as experience from matching a sibling domain such as experience-archive
- add a regression test for the colliding-prefix case

Closes #17

## Testing

- uv run pytest -q --cov=agent_memory --cov-report=term-missing --cov-fail-under=85 (389 passed, 90.91% coverage)
- uv run ruff check .
- uv run mypy