### PR TITLE
Say why a name derived from non-ASCII key fields has none, and print it

### DIFF
--- a/packages/cli/src/agent_memory/cli/main.py
+++ b/packages/cli/src/agent_memory/cli/main.py
@@ -27,6 +27,7 @@ REASON_HOST = "host"
 REASON_ENDPOINT = "endpoint"
 REASON_NONE = "none"
 EMIT_INDENT = 2
+FIELD_ERROR_KEYS = frozenset({"field", "reason"})
 EXIT_OK = 0
 EXIT_ERROR = 1
 EXIT_INVALID = 2
@@ -505,6 +506,8 @@ def _emit(payload: object, as_json: bool, stream=None) -> None:
 
 
 def _line(item: dict[str, object]) -> str:
+    if frozenset(item) == FIELD_ERROR_KEYS:
+        return f"{item['field']}: {item['reason']}"
     name = item.get("name", "")
     abstract = item.get("abstract", "")
     path = item.get("path", "")

--- a/packages/core/src/agent_memory/core/placement.py
+++ b/packages/core/src/agent_memory/core/placement.py
@@ -102,7 +102,9 @@ def resolve(
         raw_group = settled[schema.group]
         group = portable_segment(raw_group, config)
         if not group:
-            raise ValidationError([FieldError(schema.group, "empty after slugging")])
+            raise ValidationError(
+                [FieldError(schema.group, "has no ASCII letters or digits to name its directory")]
+            )
         source = source_of(schema.group, config)
         if source == SOURCE_MENU and not (
             group in existing_groups or group == config.storage.default_group or create_group
@@ -125,7 +127,14 @@ def resolve(
         SEGMENT_SEPARATOR.join(settled[field] for field in schema.key_without_group), config
     )
     if not stem:
-        raise ValidationError([FieldError("name", "key fields produce an empty name")])
+        raise ValidationError(
+            [
+                FieldError(
+                    "name",
+                    "key fields have no ASCII letters or digits to name the file; pass name",
+                )
+            ]
+        )
     parts = [schema.type] + ([group] if group else []) + [stem + MEMORY_SUFFIX]
     if len(parts) > config.storage.max_depth:
         raise ValidationError([FieldError("path", "exceeds max_depth")])

--- a/tests/system/test_cli.py
+++ b/tests/system/test_cli.py
@@ -57,6 +57,13 @@ def test_invalid_write_returns_a_structured_error_and_a_distinct_exit_code(cli):
     assert any(error["field"] == "type" for error in payload["errors"])
 
 
+def test_a_rejected_write_prints_the_field_and_the_reason(cli, capsys):
+    argv = ("record", "--type", "fact", "--abstract", "重构后的部署流程记录")
+    (error,) = cli(*argv, expect=EXIT_INVALID)["errors"]
+    assert main(["--store", str(cli.root), *argv]) == EXIT_INVALID
+    assert f"{error['field']}: {error['reason']}" in capsys.readouterr().err
+
+
 def test_read_levels_are_available_from_the_command_line(cli):
     cli(
         "record",

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -163,3 +163,32 @@ def test_slugify_is_idempotent_and_produces_valid_slugs(config):
         if once:
             assert is_valid_slug(once)
             assert slugify(once, config.storage.slug_max_length) == once
+
+
+def test_a_derived_name_names_the_cause_and_the_way_out(store):
+    with pytest.raises(ValidationError) as raised:
+        store.record(abstract="重构后的部署流程记录", type="fact")
+    (error,) = raised.value.errors
+    assert error.field == "name"
+    assert "ASCII" in error.reason
+    assert "name" in error.reason
+
+
+def test_a_non_ascii_abstract_is_written_under_an_explicit_name(store):
+    written = store.record(
+        abstract="重构后的部署流程记录", type="fact", name="deploy-rewrite-notes"
+    )
+    assert written.name == "deploy-rewrite-notes"
+    assert written.path.name == "deploy-rewrite-notes.md"
+
+
+def test_a_group_that_slugs_to_nothing_names_the_cause(store):
+    with pytest.raises(ValidationError) as raised:
+        store.record(
+            abstract="Prefers short answers",
+            type="preference",
+            name="short-answers",
+            fields={"topic": "沟通"},
+        )
+    assert "topic" in {error.field for error in raised.value.errors}
+    assert "ASCII" in " ".join(error.reason for error in raised.value.errors)


### PR DESCRIPTION
Refs #20.

## What reproduces at 34d12a2

`slugify` drops every character that is not ASCII alphanumeric, so input written
entirely in CJK, Arabic, or Cyrillic folds to the empty string. Eight of the nine
factory types derive their file name from the abstract through `portable_segment`
(`profile` is the exception: it keys on the system-supplied `user`), so the write
path the prompts teach — `--type` and `--abstract`, no `--name` — rejects such a
write. A group value that slugs to nothing fails the same way.

## What does not reproduce

The issue reports "a file named `.md` at the domain root", with non-ASCII abstracts
colliding on one path and overwriting each other. That is not the behaviour at
34d12a2: `placement.resolve` raises before any path is built, and no file is
created. The probe in the linked evidence shows the rejection and an empty store.
So this is not a data-loss bug at HEAD — it is a write that fails with a message
the caller cannot act on.

## The change

Two defects, one user-visible outcome: a rejected write the user can act on.

**The wording.** In core, the rejection stays. A digest or transliterated fallback
would put unreadable names in a tree whose whole point is being walkable with `ls`
and `grep`, and a transliteration table is a dependency this repo does not take.
What changes is the diagnostic, which now names the cause and the way out:

```
name: key fields have no ASCII letters or digits to name the file; pass name
topic: has no ASCII letters or digits to name its directory
```

**The output path.** `errors.py` promises that a rejected write says which field
and why, and the JSON payload keeps that promise — but the plain renderer did not.
`_emit` formatted *every* list entry with the recall line, so any `ValidationError`
printed as

```
errors:
  -  —  ·  · score=None
```

with the field and the reason silently dropped. Wording a diagnostic better is
worth nothing on the output path most callers read, so a field error now renders as
`field: reason`:

```
code: validation_error
errors:
  - name: key fields have no ASCII letters or digits to name the file; pass name
```

Verified end to end: the rejected write names the field and the way out in the
default output mode, `mem record --help` shows that field as `--name`, and the same
abstract with `--name deploy-rewrite-notes` lands at
`fact/default/deploy-rewrite-notes.md`.

If the maintainers would rather that a non-ASCII abstract *succeed*, that is a
naming-policy decision — it needs an ASCII-safe fallback and a view on how legible
the resulting tree stays — and I would rather raise it than pick for you.

## Tests

`tests/unit/test_storage.py`

- `test_a_derived_name_names_the_cause_and_the_way_out` — the rejection carries the cause
- `test_a_non_ascii_abstract_is_written_under_an_explicit_name` — the promised way out works
- `test_a_group_that_slugs_to_nothing_names_the_cause` — the sibling path

The first and third fail on 34d12a2 with the old wording and pass after; the second
passes on both, which is the point — an explicit name was always the way through.

`tests/system/test_cli.py`

- `test_a_rejected_write_prints_the_field_and_the_reason` — the plain output carries
  the same field and reason the structured payload does. It reads its expected text
  out of that payload instead of pinning the message, and it fails on the previous
  commit with the blank line shown above.

## Validation

Local replica of `.github/workflows/ci.yml`: `ruff check` clean, `ruff format
--check` clean, `mypy` clean (66 source files), `pytest` 392 passed, coverage 91.01%
against the 85% gate.
